### PR TITLE
find_chrome_executable: Search `PATH` in order

### DIFF
--- a/nodriver/core/config.py
+++ b/nodriver/core/config.py
@@ -295,22 +295,13 @@ def find_chrome_executable(return_all=False):
                 % candidate
             )
 
-    winner = None
+    if not rv:
+        raise FileNotFoundError(
+            "could not find a valid chrome browser binary. please make sure chrome is installed."
+            "or use the keyword argument 'browser_executable_path=/path/to/your/browser' "
+        )
 
-    if return_all and rv:
+    if return_all:
         return rv
 
-    if rv and len(rv) > 1:
-        # assuming the shortest path wins
-        winner = min(rv, key=lambda x: len(x))
-
-    elif len(rv) == 1:
-        winner = rv[0]
-
-    if winner:
-        return os.path.normpath(winner)
-
-    raise FileNotFoundError(
-        "could not find a valid chrome browser binary. please make sure chrome is installed."
-        "or use the keyword argument 'browser_executable_path=/path/to/your/browser' "
-    )
+    return os.path.normpath(rv[0])


### PR DESCRIPTION
From <https://pubs.opengroup.org/onlinepubs/9699919799/basedefs/V1_chap08.html#tag_08_03>:

> PATH
    ... The list shall be searched from beginning to end, applying the filename to each prefix, until an executable file with the specified name and appropriate execution permissions is found. ...