### PR TITLE
element.get_position: Don't raise when empty `quads`

### DIFF
--- a/nodriver/core/element.py
+++ b/nodriver/core/element.py
@@ -490,8 +490,6 @@ class Element:
             quads = await self.tab.send(
                 cdp.dom.get_content_quads(object_id=self.remote_object.object_id)
             )
-            if not quads:
-                raise Exception("could not find position for %s " % self)
             pos = Position(quads[0])
             if abs:
                 scroll_y = (await self.tab.evaluate("window.scrollY")).value
@@ -904,10 +902,8 @@ class Element:
                 )
             except ProtocolException:
                 return
-        try:
-            pos = await self.get_position()
-
-        except (Exception,):
+        pos = await self.get_position()
+        if not pos:
             logger.debug("flash() : could not determine position")
             return
 


### PR DESCRIPTION
I think `quads` being empty is already handled by catching the `IndexError` raised from the line below:
https://github.com/ultrafunkamsterdam/nodriver/blob/e630abfc5dce2023966a61cec739348b18bd465d/nodriver/core/element.py#L495