### PR TITLE
fix headless user agent and wrong placed print statement

### DIFF
--- a/nodriver/core/browser.py
+++ b/nodriver/core/browser.py
@@ -388,6 +388,15 @@ class Browser:
             ]
             await self.connection.send(cdp.target.set_discover_targets(discover=True))
         await self
+
+        if self.config.headless:
+            user_agent = await self.main_tab.send(cdp.runtime.evaluate(
+                        expression="navigator.userAgent",
+                        return_by_value=True
+                    ))
+            user_agent = user_agent[0].value.replace('Headless','')
+            await self.main_tab.send(cdp.network.set_user_agent_override(user_agent))
+
         # self.connection.handlers[cdp.inspector.Detached] = [self.stop]
         # return self
 

--- a/nodriver/core/util.py
+++ b/nodriver/core/util.py
@@ -140,6 +140,7 @@ def deconstruct_browser():
             try:
                 if _.config and not _.config.uses_custom_data_dir:
                     shutil.rmtree(_.config.user_data_dir, ignore_errors=False)
+                    print("successfully removed temp profile %s" % _.config.user_data_dir)
             except FileNotFoundError as e:
                 break
             except (PermissionError, OSError) as e:
@@ -152,7 +153,7 @@ def deconstruct_browser():
                     break
                 time.sleep(0.15)
                 continue
-        print("successfully removed temp profile %s" % _.config.user_data_dir)
+        
 
 
 def filter_recurse_all(


### PR DESCRIPTION
Remove the word Headless from user agent if headless is True
and moved print statement because when you set a user_data_dir and open multiple chromes windows with it, it will says that it  delete X ammount of the same user_data_dir when it didnt 