### PR TITLE
fix: resolve deadlock and KeyError 'sameParty' in network.Cookie

### DIFF
--- a/nodriver/cdp/network.py
+++ b/nodriver/cdp/network.py
@@ -1362,7 +1362,7 @@ class Cookie:
     #: Cookie expiration date as the number of seconds since the UNIX epoch.
     #: The value is set to -1 if the expiry date is not set.
     #: The value can be null for values that cannot be represented in
-    #: JSON (±Inf).
+    #: JSON (ï¿½Inf).
     expires: typing.Optional[float] = None
 
     #: Cookie SameSite type.
@@ -1409,14 +1409,14 @@ class Cookie:
             http_only=bool(json['httpOnly']),
             secure=bool(json['secure']),
             session=bool(json['session']),
-            priority=CookiePriority.from_json(json['priority']),
-            same_party=bool(json['sameParty']),
-            source_scheme=CookieSourceScheme.from_json(json['sourceScheme']),
-            source_port=int(json['sourcePort']),
-            expires=float(json['expires']) if json.get('expires', None) is not None else None,
-            same_site=CookieSameSite.from_json(json['sameSite']) if json.get('sameSite', None) is not None else None,
-            partition_key=CookiePartitionKey.from_json(json['partitionKey']) if json.get('partitionKey', None) is not None else None,
-            partition_key_opaque=bool(json['partitionKeyOpaque']) if json.get('partitionKeyOpaque', None) is not None else None,
+            priority=CookiePriority.from_json(json.get('priority', 'Medium')),
+            same_party=bool(json.get('sameParty', False)),
+            source_scheme=CookieSourceScheme.from_json(json.get('sourceScheme', 'Unset')),
+            source_port=int(json.get('sourcePort', -1)),
+            expires=float(json['expires']) if json.get('expires') is not None else None,
+            same_site=CookieSameSite.from_json(json.get('sameSite',"")) if json.get('sameSite') is not None else None,
+            partition_key=CookiePartitionKey.from_json(json.get('partitionKey',{})) if json.get('partitionKey') is not None else None,
+            partition_key_opaque=bool(json.get('partitionKeyOpaque')) if json.get('partitionKeyOpaque') is not None else None,
         )
 
 


### PR DESCRIPTION
Calling browser.cookies.get_all() or any method involving cdp.storage.get_cookies() causes the program to hang indefinitely (deadlock) when using recent versions of Chrome.

Reproduction Script:

```python
import asyncio
import logging

import nodriver as uc

logging.basicConfig(level=logging.DEBUG)


async def reproduce_issue():
    print("Starting browser...")
    browser = await uc.start()

    try:
        page = await browser.get("https://www.google.com")
        await page.wait(2)

        try:
            cookies = await asyncio.wait_for(browser.cookies.get_all(), timeout=5.0)

            print(f"SUCCESS: Retrieved {len(cookies)} cookies.")

        except asyncio.TimeoutError:
            print("\n" + "!" * 60)
            print("FAILURE REPRODUCED: The operation timed out after 5 seconds!")
            print("The 'get_all()' call is stuck in a deadlock because an internal")
            print("KeyError (sameParty) occurred in the background CDP task.")
            print("!" * 60 + "\n")

    finally:
        print("Cleaning up...")
        browser.stop()
        await asyncio.sleep(2)


if __name__ == "__main__":
    asyncio.run(reproduce_issue())

```

Proposed Fix:

Update `network.Cookie.from_json` to use .get() with default values for deprecated or optional fields like sameParty, sourceScheme, and partitionKey. This makes the parser more resilient to future CDP changes.